### PR TITLE
Remove <feff> special character that causes uglify.js crash

### DIFF
--- a/jquery.caret.js
+++ b/jquery.caret.js
@@ -5,7 +5,7 @@
  * http://www.opensource.org/licenses/mit-license.php
  *
  */
-﻿(function($,len,createRange,duplicate){
+(function($,len,createRange,duplicate){
 	$.fn.caret=function(options,opt2){
 		var start,end,t=this[0],browser=(/(msie) ([\w.]+)/.exec(navigator.userAgent.toLowerCase()) || [])[1];
 		if(typeof options==="object" && typeof options.start==="number" && typeof options.end==="number") {


### PR DESCRIPTION
For some reason line 8 had leading <feff> char. This caused Uglify.js to throw an error.
